### PR TITLE
테스트 과정에 TypeScript 3.8 타입 체크 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7458,6 +7458,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
+    },
     "underscore": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "onchange": "^6.1.0",
     "raw-loader": "^4.0.0",
     "sucrase": "^3.12.1",
+    "typescript": "^3.8.3",
     "webpack": "^4.42.0",
     "webpack-command": "^0.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "watch": "npm run build && run-p watch:*",
     "watch:build": "webpack --config ./build/webpack.config.ts --require sucrase/register/ts --watch",
     "watch:jison": "onchange 'src/parser/parser.jison' -- npm run build:jison",
+    "pretest": "tsc --noEmit",
     "test": "npm run build:test && node ./dist/test.js",
     "test:debug": "npm run build:test && node inspect ./dist/test.js",
     "prepublish": "node ./build/in-publish && npm test && npm run build-production || node ./build/not-in-publish"

--- a/src/ast/index.js
+++ b/src/ast/index.js
@@ -709,4 +709,5 @@ export class Translate extends Def {
     }
 }
 
-export NodeVisitor from './NodeVisitor';
+import NodeVisitor from './NodeVisitor';
+export { NodeVisitor };

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -5,5 +5,6 @@ export const AFTER_ANALYZE = {};
 export const BEFORE_TRANSLATE = {};
 export const AFTER_TRANSLATE = {};
 
-export Compiler from './Compiler';
-export JsTargetCompiler from './JsTargetCompiler';
+import Compiler from './Compiler';
+import JsTargetCompiler from './JsTargetCompiler';
+export { Compiler, JsTargetCompiler };

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -1,3 +1,4 @@
-export Resolver from './Resolver';
+import Resolver from './Resolver';
+export { Resolver };
 export * as context from './context';
 export * as loader from './loader';

--- a/src/module/loader/index.js
+++ b/src/module/loader/index.js
@@ -1,2 +1,3 @@
-export Loader from './Loader';
-export CommonLoader from './CommonLoader';
+import Loader from './Loader';
+import CommonLoader from './CommonLoader';
+export { CommonLoader, Loader };

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -1,1 +1,2 @@
-export Parser from './Parser';
+import Parser from './Parser';
+export { Parser };

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -1,3 +1,8 @@
-export Plugin from './Plugin';
-export ConstantFolder from './ConstantFolder';
-export UnusedDefRemover from './UnusedDefRemover';
+import Plugin from './Plugin';
+import ConstantFolder from './ConstantFolder';
+import UnusedDefRemover from './UnusedDefRemover';
+export {
+    ConstantFolder,
+    Plugin,
+    UnusedDefRemover,
+};

--- a/src/translator/index.js
+++ b/src/translator/index.js
@@ -1,3 +1,8 @@
-export Translator from './Translator';
-export TextTranslator from './TextTranslator';
-export JsTranslator from './JsTranslator';
+import Translator from './Translator';
+import TextTranslator from './TextTranslator';
+import JsTranslator from './JsTranslator';
+export {
+    JsTranslator,
+    TextTranslator,
+    Translator,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,8 @@
     }
   },
   "exclude": [
+    "dist",
+    "dump",
     "node_modules"
   ]
 }


### PR DESCRIPTION
Resolves #29.

TypeScript 버전은 지금 쓸 수 있는 최신 버전으로 임의로 정했습니다.

`tsconfig.json`에 `allowJs` 옵션이 활성화된 덕에 tsc가 `*.js` 파일까지 검사하게 되며, 이에 따라 기존의 자바스크립트 코드 중 TypeScript가 인식하지 못하는 문법을 수정했습니다.