### PR TITLE
TypeScript 마이그레이션: ast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1128,6 +1128,12 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "13.7.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.6",
     "@babel/preset-typescript": "^7.8.3",
+    "@types/mocha": "^2.2.48",
     "@types/webpack": "^4.41.7",
     "babel-loader": "^8.0.6",
     "del-cli": "^3.0.0",

--- a/src/ast/NodeVisitor.ts
+++ b/src/ast/NodeVisitor.ts
@@ -1,11 +1,13 @@
 import * as ast from '~/ast';
 
 export default class NodeVisitor {
+    translateTargets: any[];
+
     constructor() {
         this.translateTargets = [];
     }
     async init() {}
-    async visit(node) {
+    async visit(node: ast.AstNode) {
         if (node instanceof ast.YaksokRoot) return await this.visitYaksokRoot(node);
         if (node instanceof ast.Statements) return await this.visitStatements(node);
         if (node instanceof ast.Statement) return await this.visitStatement(node);
@@ -16,9 +18,9 @@ export default class NodeVisitor {
         if (node instanceof ast.DescriptionName) return await this.visitDescriptionName(node);
         throw new Error('unknown node type');
     }
-    async visitYaksokRoot(node) { await this.visitStatements(node.statements); }
-    async visitStatements(node) { for (let statement of Array.from(node)) await this.visitStatement(statement); }
-    async visitStatement(node) {
+    async visitYaksokRoot(node: ast.YaksokRoot) { await this.visitStatements(node.statements); }
+    async visitStatements(node: ast.Statements) { for (let statement of Array.from(node)) if (statement != null) await this.visitStatement(statement); }
+    async visitStatement(node: ast.Statement) {
         if (node instanceof ast.PlainStatement) return await this.visitPlainStatement(node);
         if (node instanceof ast.Assign) return await this.visitAssign(node);
         if (node instanceof ast.Outside) return await this.visitOutside(node);
@@ -30,47 +32,47 @@ export default class NodeVisitor {
         if (node instanceof ast.Def) return await this.visitDef(node);
         throw new Error('unknown node type');
     }
-    async visitPlainStatement(node) { await this.visitExpression(node.expression); }
-    async visitAssign(node) {
+    async visitPlainStatement(node: ast.PlainStatement) { await this.visitExpression(node.expression); }
+    async visitAssign(node: ast.Assign) {
         await this.visit(node.rvalue); // attention: evaluation order
         await this.visit(node.lvalue);
     }
-    async visitOutside(node) {
+    async visitOutside(node: ast.Outside) {
         await this.visit(node.name);
     }
-    async visitCall(node) {}
-    async visitModuleCall(node) {}
-    async visitCallBind(node) {}
-    async visitModuleCallBind(node) {}
-    async visitCondition(node) {
+    async visitCall(node: ast.Call) {}
+    async visitModuleCall(node: ast.ModuleCall) {}
+    async visitCallBind(node: ast.CallBind) {}
+    async visitModuleCallBind(node: ast.ModuleCallBind) {}
+    async visitCondition(node: ast.Condition) {
         if (node instanceof ast.If) return await this.visitIf(node);
         if (node instanceof ast.IfNot) return await this.visitIfNot(node);
         throw new Error('unknown node type');
     }
-    async visitIf(node) {
+    async visitIf(node: ast.If) {
         await this.visit(node.condition);
         await this.visitStatements(node.ifBlock);
         if (node.elseBlock) {
             await this.visitStatements(node.elseBlock);
         }
     }
-    async visitIfNot(node) {
+    async visitIfNot(node: ast.IfNot) {
         await this.visit(node.condition);
         await this.visitStatements(node.ifBlock);
         if (node.elseBlock) {
             await this.visitStatements(node.elseBlock);
         }
     }
-    async visitLoop(node) { await this.visit(node.block); }
-    async visitIterate(node) {
+    async visitLoop(node: ast.Loop) { await this.visit(node.block); }
+    async visitIterate(node: ast.Iterate) {
         await this.visit(node.iteratee);
         await this.visit(node.iterator);
         await this.visit(node.block);
     }
-    async visitLoopEnd(node) {}
-    async visitYaksokEnd(node) {}
-    async visitExpressions(node) { for (let expression of Array.from(node)) await this.visitExpression(expression); }
-    async visitExpression(node) {
+    async visitLoopEnd(node: ast.LoopEnd) {}
+    async visitYaksokEnd(node: ast.YaksokEnd) {}
+    async visitExpressions(node: ast.Expressions) { for (let expression of Array.from(node)) if (expression != null) await this.visitExpression(expression); }
+    async visitExpression(node: ast.Expression) {
         if (node instanceof ast.Call) return await this.visitCall(node);
         if (node instanceof ast.ModuleCall) return await this.visitModuleCall(node);
         if (node instanceof ast.CallBind) return await this.visitCallBind(node);
@@ -84,7 +86,7 @@ export default class NodeVisitor {
         if (node instanceof ast.Question) return await this.visitQuestion(node);
         throw new Error('unknown node type');
     }
-    async visitPrimitive(node) {
+    async visitPrimitive(node: ast.Primitive) {
         if (node instanceof ast.Name) return await this.visitName(node);
         if (node instanceof ast.String) return await this.visitString(node);
         if (node instanceof ast.Integer) return await this.visitInteger(node);
@@ -93,30 +95,30 @@ export default class NodeVisitor {
         if (node instanceof ast.Void) return await this.visitVoid(node);
         throw new Error('unknown node type');
     }
-    async visitName(node) {}
-    async visitString(node) {}
-    async visitInteger(node) {}
-    async visitFloat(node) {}
-    async visitBoolean(node) {}
-    async visitVoid(node) {}
-    async visitQuestion(node) {}
-    async visitRange(node) {
+    async visitName(node: ast.Name) {}
+    async visitString(node: ast.String) {}
+    async visitInteger(node: ast.Integer) {}
+    async visitFloat(node: ast.Float) {}
+    async visitBoolean(node: ast.Boolean) {}
+    async visitVoid(node: ast.Void) {}
+    async visitQuestion(node: ast.Question) {}
+    async visitRange(node: ast.Range) {
         await this.visit(node.start);
         await this.visit(node.stop);
     }
-    async visitList(node) { for (let item of Array.from(node)) await this.visitExpression(item); }
-    async visitDict(node) { for (let item of Array.from(node)) await this.visitDictKeyValue(item); }
-    async visitDictKeyValue(node) {
+    async visitList(node: ast.List) { for (let item of Array.from(node)) if (item != null) await this.visitExpression(item); }
+    async visitDict(node: ast.Dict) { for (let item of Array.from(node)) if (item != null) await this.visitDictKeyValue(item); }
+    async visitDictKeyValue(node: ast.DictKeyValue) {
         await this.visitName(node.key);
         await this.visitExpression(node.value);
     }
-    async visitUnaryOperator(node) {
+    async visitUnaryOperator(node: ast.UnaryOperator) {
         if (node instanceof ast.UnaryPlus) return await this.visitUnaryPlus(node);
         if (node instanceof ast.UnaryMinus) return await this.visitUnaryMinus(node);
     }
-    async visitUnaryPlus(node) { await visitUnaryOperator.call(this, node); }
-    async visitUnaryMinus(node) { await visitUnaryOperator.call(this, node); }
-    async visitBinaryOperator(node) {
+    async visitUnaryPlus(node: ast.UnaryPlus) { await visitUnaryOperator.call(this, node); }
+    async visitUnaryMinus(node: ast.UnaryMinus) { await visitUnaryOperator.call(this, node); }
+    async visitBinaryOperator(node: ast.BinaryOperator) {
         if (node instanceof ast.Access) return await this.visitAccess(node);
         if (node instanceof ast.DotAccess) return await this.visitDotAccess(node);
         if (node instanceof ast.Or) return await this.visitOr(node);
@@ -134,40 +136,40 @@ export default class NodeVisitor {
         if (node instanceof ast.Modular) return await this.visitModular(node);
         throw new Error('unknown node type');
     }
-    async visitAccess(node) { await visitOperator.call(this, node); }
-    async visitDotAccess(node) { await visitOperator.call(this, node); }
-    async visitOr(node) { await visitOperator.call(this, node); }
-    async visitAnd(node) { await visitOperator.call(this, node); }
-    async visitEqual(node) { await visitOperator.call(this, node); }
-    async visitNotEqual(node) { await visitOperator.call(this, node); }
-    async visitGreaterThan(node) { await visitOperator.call(this, node); }
-    async visitLessThan(node) { await visitOperator.call(this, node); }
-    async visitGreaterThanEqual(node) { await visitOperator.call(this, node); }
-    async visitLessThanEqual(node) { await visitOperator.call(this, node); }
-    async visitPlus(node) { await visitOperator.call(this, node); }
-    async visitMinus(node) { await visitOperator.call(this, node); }
-    async visitMultiply(node) { await visitOperator.call(this, node); }
-    async visitDivide(node) { await visitOperator.call(this, node); }
-    async visitModular(node) { await visitOperator.call(this, node); }
-    async visitDescription(node) {}
-    async visitDescriptionParameter(node) {}
-    async visitDescriptionName(node) {}
-    async visitDef(node) {
+    async visitAccess(node: ast.Access) { await visitOperator.call(this, node); }
+    async visitDotAccess(node: ast.DotAccess) { await visitOperator.call(this, node); }
+    async visitOr(node: ast.Or) { await visitOperator.call(this, node); }
+    async visitAnd(node: ast.And) { await visitOperator.call(this, node); }
+    async visitEqual(node: ast.Equal) { await visitOperator.call(this, node); }
+    async visitNotEqual(node: ast.NotEqual) { await visitOperator.call(this, node); }
+    async visitGreaterThan(node: ast.GreaterThan) { await visitOperator.call(this, node); }
+    async visitLessThan(node: ast.LessThan) { await visitOperator.call(this, node); }
+    async visitGreaterThanEqual(node: ast.GreaterThanEqual) { await visitOperator.call(this, node); }
+    async visitLessThanEqual(node: ast.LessThanEqual) { await visitOperator.call(this, node); }
+    async visitPlus(node: ast.Plus) { await visitOperator.call(this, node); }
+    async visitMinus(node: ast.Minus) { await visitOperator.call(this, node); }
+    async visitMultiply(node: ast.Multiply) { await visitOperator.call(this, node); }
+    async visitDivide(node: ast.Divide) { await visitOperator.call(this, node); }
+    async visitModular(node: ast.Modular) { await visitOperator.call(this, node); }
+    async visitDescription(node: ast.Description) {}
+    async visitDescriptionParameter(node: ast.DescriptionParameter) {}
+    async visitDescriptionName(node: ast.DescriptionName) {}
+    async visitDef(node: ast.Def) {
         if (node instanceof ast.Yaksok) return await this.visitYaksok(node);
         if (node instanceof ast.Translate) return await this.visitTranslate(node);
         throw new Error('unknown node type');
     }
-    async visitYaksok(node) {
+    async visitYaksok(node: ast.Yaksok): Promise<any> {
         return await this.visit(node.block);
     }
-    async visitTranslate(node) {}
+    async visitTranslate(node: ast.Translate) {}
 }
 
-async function visitUnaryOperator(node) {
+async function visitUnaryOperator(this: NodeVisitor, node: ast.UnaryOperator) {
     await this.visit(node.rhs);
 }
 
-async function visitOperator(node) {
+async function visitOperator(this: NodeVisitor, node: ast.BinaryOperator) {
     await this.visit(node.lhs);
     await this.visit(node.rhs);
 }

--- a/src/ast/base.ts
+++ b/src/ast/base.ts
@@ -122,14 +122,14 @@ export function astList<T>(listFieldName: string) {
             enumerable: false,
             get() { return this[listFieldName]; }
         });
-        applyMixins(target, AstListMixin);
+        applyMixin(target, AstListMixin);
     };
 }
 
-function applyMixins(target: any, mixin: any) {
-    const properties: (string | symbol)[] = Object.getOwnPropertyNames(mixin);
-    properties.push(...Object.getOwnPropertySymbols(mixin));
+function applyMixin(target: any, mixin: any) {
+    const properties: (string | symbol)[] = Object.getOwnPropertyNames(mixin.prototype);
+    properties.push(...Object.getOwnPropertySymbols(mixin.prototype));
     for (const name of properties) {
-        Object.defineProperty(target.prototype, name, Object.getOwnPropertyDescriptor(mixin, name)!);
+        Object.defineProperty(target.prototype, name, Object.getOwnPropertyDescriptor(mixin.prototype, name)!);
     }
 }

--- a/src/ast/base.ts
+++ b/src/ast/base.ts
@@ -45,7 +45,7 @@ export abstract class AstNode {
 }
 
 export function child(target: any, field: string): any {
-    addChildFields(target.constructor, field);
+    addChildFields(target, field);
     const privateField = '_' + field;
     return {
         configurable: true,

--- a/src/ast/base.ts
+++ b/src/ast/base.ts
@@ -1,0 +1,64 @@
+const childFieldsMap = new WeakMap<any, string[]>();
+
+function addChildFields(target: any, field: string) {
+    let childFields = childFieldsMap.get(target);
+    if (childFields == null) {
+        childFields = [];
+        childFieldsMap.set(target, childFields);
+    }
+    childFields.push(field);
+}
+
+export function* allChildFields(target: any) {
+    while (target != null && target !== AstNode && target !== Function) {
+        const childFields = childFieldsMap.get(target) ?? [];
+        yield* childFields;
+        target = Object.getPrototypeOf(target);
+    }
+}
+
+// ast
+export abstract class AstNode {
+    parent: AstNode | null;
+
+    constructor() {
+        this.parent = null;
+    }
+
+    replaceChild<T extends AstNode>(before: T, after: T) {
+        for (let field of allChildFields(this)) {
+            if ((this as any)[field] === before) {
+                after.parent = this;
+                (this as any)[field] = after;
+                return after;
+            }
+        }
+        throw new Error('이 노드의 자식이 아닙니다.');
+    }
+
+    replace(after: this) {
+        if (this.parent === null) {
+            throw new Error('부모가 없습니다.');
+        }
+        return this.parent.replaceChild(this, after);
+    }
+}
+
+export function child(target: any, field: string) {
+    addChildFields(target.constructor, field);
+    const privateField = '_' + field;
+    Object.defineProperty(target, field, {
+        configurable: true,
+        enumerable: false,
+        get: function () {
+            let member = this[privateField];
+            return member ? member : null;
+        },
+        set: function (value) {
+            if (value !== null) {
+                value.parent = this;
+            }
+            this[privateField] = value;
+        }
+    });
+}

--- a/src/ast/base.ts
+++ b/src/ast/base.ts
@@ -44,18 +44,18 @@ export abstract class AstNode {
     }
 }
 
-export function child(target: any, field: string) {
+export function child(target: any, field: string): any {
     addChildFields(target.constructor, field);
     const privateField = '_' + field;
-    Object.defineProperty(target, field, {
+    return {
         configurable: true,
         enumerable: false,
-        get: function () {
+        get: function (this: any) {
             let member = this[privateField];
             return member ? member : null;
         },
-        set: function (value) {
-            if (value !== null) {
+        set: function (this: any, value: any) {
+            if (value != null) {
                 value.parent = this;
             }
             this[privateField] = value;

--- a/src/ast/base.ts
+++ b/src/ast/base.ts
@@ -25,7 +25,7 @@ export abstract class AstNode {
         this.parent = null;
     }
 
-    replaceChild(before: any, after: any) {
+    replaceChild<T extends AstNode>(before: AstNode, after: T): T {
         for (let field of allChildFields(this)) {
             if ((this as any)[field] === before) {
                 after.parent = this;
@@ -36,7 +36,7 @@ export abstract class AstNode {
         throw new Error('이 노드의 자식이 아닙니다.');
     }
 
-    replace(after: this) {
+    replace<T extends AstNode>(after: T): T {
         if (this.parent === null) {
             throw new Error('부모가 없습니다.');
         }
@@ -65,7 +65,7 @@ export function child(target: any, field: string): any {
 
 const listField = Symbol('listField');
 
-class AstListMixin<T extends AstNode> extends AstNode {
+export abstract class AstListMixin<T extends AstNode = AstNode> {
     [listField]: (T | null)[];
 
     get length() {
@@ -74,7 +74,7 @@ class AstListMixin<T extends AstNode> extends AstNode {
 
     push(childNode: T | null) {
         if (childNode != null) {
-            childNode.parent = this;
+            childNode.parent = this as any;
         }
         this[listField].push(childNode);
     }
@@ -83,21 +83,22 @@ class AstListMixin<T extends AstNode> extends AstNode {
         return this[listField][Symbol.iterator]();
     }
 
-    replaceChild(before: any, after: any) {
-        let index = this[listField].indexOf(before);
+    replaceChild<T extends AstNode>(before: AstNode, after: T): T {
+        let index = this[listField].indexOf(before as any);
         if (index === -1) {
             throw new Error('이 노드의 자식이 아닙니다.');
         }
         if (isSameType(after, this)) { // after가 목록인 경우
             for (let child of after[listField]) {
                 if (child != null) {
-                    child.parent = this;
+                    child.parent = this as any;
                 }
             }
             this[listField].splice(index, 1, ...after[listField]);
+            return undefined as any;  // TODO
         } else {
-            after.parent = this;
-            this[listField][index] = after;
+            after.parent = this as any;
+            this[listField][index] = after as any;
             return after;
         }
     }

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -1,129 +1,35 @@
 // NOTE: 이 파일에서 String, Number, Boolean은 javascript builtin object가 아닙니다.
 
+import { AstNode, AstListMixin, astList, child } from './base';
+
+export { AstNode, child };
+
 // decorators
-function abstract(target) {
-    return class cls extends target {
-        constructor(...args) {
-            super(...args);
-            if (this.constructor === cls)
-                throw new Error('instantiating abstract class is disallowed');
-        }
-    }
-}
-
-export function ast() {
-    let childFields = Array.from(arguments);
-    return function decorator(target) {
-        for (let field of childFields) {
-            let privateField = '_' + field;
-            Object.defineProperty(target.prototype, field, {
-                configurable: true,
-                enumerable: false,
-                get: function () {
-                    let member = this[privateField];
-                    return member ? member : null;
-                },
-                set: function (value) {
-                    if (value !== null) {
-                        value.parent = this;
-                    }
-                    this[privateField] = value;
-                }
-            });
-        }
-        target.prototype.replaceChild = function replaceChild(before, after) {
-            for (let field of childFields) {
-                if (this[field] === before) {
-                    after.parent = this;
-                    this[field] = after;
-                    return after;
-                }
-            }
-            throw new Error('이 노드의 자식이 아닙니다.');
-        };
-    };
-}
-
-export function astList(listField) {
-    return function decorator(target) {
-        Object.defineProperty(target.prototype, 'length', {
-            configurable: true,
-            enumerable: false,
-            get: function () {
-                return this[listField].length;
-            }
-        });
-        target.prototype.push = function push(childNode) {
-            if (childNode !== null) {
-                childNode.parent = this;
-            }
-            this[listField].push(childNode);
-        };
-        target.prototype[Symbol.iterator] = function () {
-            return this[listField][Symbol.iterator]();
-        };
-        target.prototype.replaceChild = function replaceChild(before, after) {
-            let index = this[listField].indexOf(before);
-            if (index === -1) {
-                throw new Error('이 노드의 자식이 아닙니다.');
-            }
-            if (after.constructor === this.constructor) { // after가 목록인 경우
-                for (let child of after[listField]) {
-                    child.parent = this;
-                }
-                this[listField].splice(index, 1, ...after[listField]);
-            } else {
-                after.parent = this;
-                this[listField][index] = after;
-                return after;
-            }
-        };
-        target.prototype.removeChild = function removeChild(child) {
-            let index = this[listField].indexOf(child);
-            if (index === -1) {
-                throw new Error('이 노드의 자식이 아닙니다.');
-            }
-            this[listField].splice(index, 1);
-        };
-    };
-}
-
-export function def(target) {
-    target.prototype.match = function match(call) { // return call info or null
+export function def(target: any) {
+    target.prototype.match = function match(call: any) { // return call info or null
         return this.description.match(call.expressions);
     };
 }
 
 // ast
-@abstract
-export class AstNode {
-    constructor() {
-        this.parent = null;
-    }
-    replaceChild(before, after) {
-        // after.parent = this;
-        throw new Error('구현되지 않았습니다.');
-    }
-    replace(after) {
-        if (this.parent === null) {
-            throw new Error('부모가 없습니다.');
-        }
-        return this.parent.replaceChild(this, after);
-    }
-}
-
-@abstract
 @astList('childNodes')
-export class AstNodeList extends AstNode {
+export abstract class AstNodeList<T extends AstNode = AstNode> extends AstNode {
+    childNodes: T[];
+
     constructor() {
         super();
         this.childNodes = [];
     }
 }
+export interface AstNodeList<T> extends AstListMixin<T> {}
 
-@ast('statements')
 export class YaksokRoot extends AstNode {
-    constructor(statements) {
+    hash: any;
+    modules: any;
+    moduleScope: any;
+    @child statements: Statements;
+
+    constructor(statements: Statements) {
         super();
         this.hash = null; // module resolver 패스를 거친 뒤부터 사용 가능
         this.modules = {}; // key: module name, value: module hash
@@ -133,7 +39,9 @@ export class YaksokRoot extends AstNode {
     }
 }
 // block is statements
-export class Statements extends AstNodeList {
+export class Statements extends AstNodeList<Statement> {
+    scope: any;
+
     constructor() {
         super();
         this.scope = null; // analyzer 패스를 거친 뒤부터 접근 가능
@@ -141,23 +49,27 @@ export class Statements extends AstNodeList {
 }
 
 // statement
-export class Statement {
+export class Statement extends AstNode {
     eliminateDeadCode() { // return boolean or replacement node
         return false; // prevent elimination
     }
 }
 
-@ast('expression')
 export class PlainStatement extends Statement {
-    constructor(expression) {
+    @child expression: Expression;
+
+    constructor(expression: Expression) {
         super();
         this.expression = expression;
     }
 }
 
-@ast('lvalue', 'rvalue')
 export class Assign extends Statement {
-    constructor(lvalue, rvalue) {
+    @child lvalue: any;
+    @child rvalue: any;
+    isDeclaration: boolean;
+
+    constructor(lvalue: any, rvalue: any) {
         super();
         this.lvalue = lvalue;
         this.rvalue = rvalue;
@@ -165,20 +77,23 @@ export class Assign extends Statement {
     }
 }
 
-@ast('name')
 export class Outside extends Statement {
-    constructor(name) {
+    @child name: any;
+
+    constructor(name: any) {
         super();
         this.name = name;
     }
 }
 
-@abstract
-export class Condition extends Statement {}
+export abstract class Condition extends Statement {}
 
-@ast('condition', 'ifBlock', 'elseBlock')
 export class If extends Condition {
-    constructor(condition, ifBlock, elseBlock) {
+    @child condition: Expression;
+    @child ifBlock: any;
+    @child elseBlock: any;
+
+    constructor(condition: Expression, ifBlock: any, elseBlock: any) {
         super();
         this.condition = condition;
         this.ifBlock = ifBlock;
@@ -193,9 +108,12 @@ export class If extends Condition {
     }
 }
 
-@ast('condition', 'ifBlock', 'elseBlock')
 export class IfNot extends Condition {
-    constructor(condition, ifBlock, elseBlock) {
+    @child condition: Expression;
+    @child ifBlock: any;
+    @child elseBlock: any;
+
+    constructor(condition: Expression, ifBlock: any, elseBlock: any) {
         super();
         this.condition = condition;
         this.ifBlock = ifBlock;
@@ -210,17 +128,21 @@ export class IfNot extends Condition {
     }
 }
 
-@ast('block')
 export class Loop extends Statement {
-    constructor(block) {
+    @child block: any;
+
+    constructor(block: any) {
         super();
         this.block = block;
     }
 }
 
-@ast('iterator', 'iteratee', 'block')
 export class Iterate extends Statement {
-    constructor(iterator, iteratee, block) {
+    @child iterator: any;
+    @child iteratee: any;
+    @child block: any;
+
+    constructor(iterator: any, iteratee: any, block: any) {
         super();
         this.iterator = iterator;
         this.iteratee = iteratee;
@@ -233,76 +155,90 @@ export class LoopEnd extends Statement {}
 export class YaksokEnd extends Statement {}
 
 // expression
-export class Expressions extends AstNodeList {
+export class Expressions extends AstNodeList<Expression> {
     get repr() {
         return this.childNodes.map(childNode => childNode.repr).join(' ');
     }
 }
 export class Expression extends AstNode {
+    type: any;
     get isConstant() { return false; }
-    fold() { return this; }
+    fold(): Expression { return this; }
+    get repr(): string {
+        throw new Error('unimplemented');
+    }
 }
 Expression.prototype.type = null;
 
-@ast('expressions', 'callInfo')
 export class Call extends Expression {
-    constructor(expressions) {
+    @child expressions: Expressions | null;
+    @child callInfo: CallInfo | null;
+
+    constructor(expressions: Expressions | null) {
         super();
         this.expressions = expressions; // analyzer 패스를 거친 뒤로는 무의미
         this.callInfo = null; // analyzer 패스를 거친 뒤부터 접근 가능
     }
     fold() {
-        for (let arg of this.callInfo.args) {
+        for (let arg of this.callInfo?.args || []) {
             arg.fold();
         }
         return this; // TODO: fold call
     }
     get repr() {
-        return this.expressions.repr;
+        return this.expressions?.repr ?? '';
     }
 }
 
-@ast('target', 'expressions', 'callInfo')
 export class ModuleCall extends Expression {
-    constructor(target, expressions) {
+    @child target: any;
+    @child expressions: Expressions | null;
+    @child callInfo: CallInfo | null;
+
+    constructor(target: any, expressions: Expressions | null) {
         super();
         this.target = target;
         this.expressions = expressions; // analyzer 패스를 거친 뒤로는 무의미
         this.callInfo = null; // analyzer 패스를 거친 뒤부터 접근 가능
     }
     fold() {
-        for (let arg of this.callInfo.args) {
+        for (let arg of this.callInfo?.args || []) {
             arg.fold();
         }
         return this; // TODO: fold call
     }
     get repr() {
-        return `@${ this.target.repr } ${ this.expressions.repr }`;
+        return `@${ this.target.repr } ${ this.expressions?.repr }`;
     }
 }
 
-@ast('expressions', 'callInfo')
 export class CallBind extends Expression {
-    constructor(expressions) {
+    @child expressions: Expressions | null;
+    @child callInfo: CallInfo | null;
+
+    constructor(expressions: Expressions | null) {
         super();
         this.expressions = expressions;
         this.callInfo = null;
     }
     get repr() {
-        return `결속 ${ this.expressions.repr }`;
+        return `결속 ${ this.expressions?.repr }`;
     }
 }
 
-@ast('target', 'expressions', 'callInfo')
 export class ModuleCallBind extends Expression {
-    constructor(target, expressions) {
+    @child target: any;
+    @child expressions: Expressions | null;
+    @child callInfo: CallInfo | null;
+
+    constructor(target: any, expressions: Expressions | null) {
         super();
         this.target = target;
         this.expressions = expressions;
         this.callInfo = null;
     }
     get repr() {
-        return `결속 @${ this.target.repr } ${ this.expressions.repr }`;
+        return `결속 @${ this.target.repr } ${ this.expressions?.repr }`;
     }
 }
 export class Question extends Expression {
@@ -313,15 +249,18 @@ export class Question extends Expression {
 
 // primitive
 export class Primitive extends Expression {
-    constructor(value) { super(); this.value = value; }
+    value: any;
+    constructor(value: any) { super(); this.value = value; }
     get isConstant() { return true; }
-    clone() { return new this.constructor(this.value); }
+    clone() { return new (this.constructor as any)(this.value); }
     get repr() {
         return `${ this.value }`;
     }
 }
 export class Name extends Primitive {
-    constructor(value) {
+    value: any;
+    call: boolean;
+    constructor(value: any) {
         super(value);
         this.call = false; // true: 식별자 하나짜리 약속일지도 모름
                            // analyzer 패스에서 사용되고 난 이후에는 의미가 없다.
@@ -337,8 +276,7 @@ export class String extends Primitive {
     }
 } String.prototype.type = String;
 
-@abstract
-export class Number extends Primitive {}
+export abstract class Number extends Primitive {}
 
 export class Integer extends Number {} Integer.prototype.type = Integer;
 export class Float extends Number {} Float.prototype.type = Float;
@@ -351,9 +289,10 @@ export class Void extends Primitive {
 } Void.prototype.type = Void;
 
 // etc
-@ast('start', 'stop')
 export class Range extends Expression {
-    constructor(start, stop) {
+    @child start: any;
+    @child stop: any;
+    constructor(start: any, stop: any) {
         super();
         this.start = start;
         this.stop = stop;
@@ -363,25 +302,30 @@ Range.prototype.type = Range;
 
 @astList('items')
 export class List extends Expression {
+    items: Expression[];
     constructor() {
         super();
         this.items = [];
     }
 }
 List.prototype.type = List;
+export interface List extends AstListMixin<Expression> {}
 
 @astList('items')
 export class Dict extends Expression {
+    items: DictKeyValue[];
     constructor() {
         super();
         this.items = [];
     }
 }
 Dict.prototype.type = Dict;
+export interface Dict extends AstListMixin<DictKeyValue> {}
 
-@ast('key', 'value')
 export class DictKeyValue extends AstNode {
-    constructor(key, value) {
+    @child key: any;
+    @child value: any;
+    constructor(key: any, value: any) {
         super();
         this.key = key;
         this.value = value;
@@ -389,10 +333,9 @@ export class DictKeyValue extends AstNode {
 }
 
 // unary operator
-@abstract
-@ast('rhs')
-export class UnaryOperator extends Expression {
-    constructor(rhs) {
+export abstract class UnaryOperator extends Expression {
+    @child rhs: Expression;
+    constructor(rhs: Expression) {
         super();
         this.rhs = rhs;
     }
@@ -425,10 +368,10 @@ export class UnaryMinus extends UnaryOperator {
 }
 
 // binary opeartor
-@abstract
-@ast('lhs', 'rhs')
-export class BinaryOperator extends Expression {
-    constructor(lhs, rhs) {
+export abstract class BinaryOperator extends Expression {
+    @child lhs: Expression;
+    @child rhs: Expression;
+    constructor(lhs: Expression, rhs: Expression) {
         super();
         this.lhs = lhs;
         this.rhs = rhs;
@@ -445,7 +388,11 @@ And.prototype.type = Boolean;
 export class Equal extends BinaryOperator {
     fold() {
         if (this.isConstant) {
-            return this.replace(new Boolean(this.lhs.fold().value === this.rhs.fold().value));
+            let lhs = this.lhs.fold();
+            let rhs = this.rhs.fold();
+            if (lhs instanceof Primitive && rhs instanceof Primitive) {
+                return this.replace(new Boolean(lhs.value === rhs.value));
+            }
         }
         return this;
     }
@@ -454,7 +401,11 @@ Equal.prototype.type = Boolean;
 export class NotEqual extends BinaryOperator {
     fold() {
         if (this.isConstant) {
-            return this.replace(new Boolean(this.lhs.fold().value !== this.rhs.fold().value));
+            let lhs = this.lhs.fold();
+            let rhs = this.rhs.fold();
+            if (lhs instanceof Primitive && rhs instanceof Primitive) {
+                return this.replace(new Boolean(lhs.value !== rhs.value));
+            }
         }
         return this;
     }
@@ -578,16 +529,19 @@ export class Modular extends BinaryOperator {
 
 @astList('args')
 export class CallInfo extends AstNode {
-    constructor(def) {
+    def: any;
+    args: Expression[];
+    constructor(def: any) {
         super();
         this.def = def;
         this.args = [];
     }
 }
+export interface CallInfo extends AstListMixin {}
 
 // description
-export class Description extends AstNodeList {
-    match(expressions) {
+export class Description extends AstNodeList<Expression> {
+    match(expressions: Expressions) {
         if (expressions.length > this.length) return null;
         let callInfo = new CallInfo(this.parent);
         // FIXME: babel 6.5 대에서
@@ -606,7 +560,7 @@ export class Description extends AstNodeList {
                     callInfo.push(expression);
                     continue;
                 }
-                let next = this.childNodes[i + 1];
+                let next: DescriptionName = this.childNodes[i + 1] as any;  // assume
                 let nextExpression = expressions.childNodes[j + 1];
                 if (!next || next.match(nextExpression) || next.needWhiteSpace) {
                     callInfo.push(expression);
@@ -633,26 +587,28 @@ export class Description extends AstNodeList {
     get repr() { return this.childNodes.map(expression => expression.repr).join(''); }
 }
 export class DescriptionParameter extends AstNode {
-    constructor(value) { super(); this.value = value; }
+    value: any;
+    constructor(value: any) { super(); this.value = value; }
     get repr() { return `(${ this.value })`; }
 }
 export class DescriptionName extends AstNode {
+    names: string[];
     constructor() {
         super();
         this.names = [];
     }
     needWhiteSpace = false;
-    match(name) {
+    match(name: Expression) {
         if (!(name instanceof Name)) return false;
         return this.names.some(potential => name.value === potential);
     }
-    postMatch(param) {
+    postMatch(param: Expression) {
         if (!(param instanceof Name)) return 0;
         let match = this.names.find(potential => param.value.endsWith(potential));
         return match ? match.length : 0;
     }
     get length() { return this.names.length; }
-    push(name) {
+    push(name: string) {
         // name: string
         this.names.push(name);
     }
@@ -664,9 +620,12 @@ export class DescriptionName extends AstNode {
 }
 
 // defs
-@abstract @def
-@ast('description')
-export class Def extends Statement {
+@def
+export abstract class Def extends Statement {
+    @child description: Description | null = null;
+    scope: any;
+    returnType: any;
+    used: boolean;
     constructor() {
         super();
         this.scope = null;
@@ -676,29 +635,32 @@ export class Def extends Statement {
     }
     get hasSideEffect() { return true; }
     get repr() {
-        return `정의 ${ this.description.repr }`;
+        return `정의 ${ this.description?.repr }`;
     }
 }
 
-@ast('description', 'block')
 export class Yaksok extends Def {
-    constructor(description, block) {
+    @child description: Description;
+    @child block: any;
+    constructor(description: Description, block: any) {
         super();
         this.description = description;
         this.block = block;
     }
     get hasSideEffect() {
         // TODO: 현재 약속의 부수효과 여부 반환
-        return super.hasSideEffect();
+        return super.hasSideEffect;
     }
     get repr() {
         return `약속 ${ this.description.repr }`;
     }
 }
 
-@ast('description')
 export class Translate extends Def {
-    constructor(description, target, code) {
+    @child description: Description;
+    target: any;
+    code: any;
+    constructor(description: Description, target: any, code: any) {
         super();
         this.description = description;
         this.target = target; // string

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -171,10 +171,10 @@ export class Expression extends AstNode {
 Expression.prototype.type = null;
 
 export class Call extends Expression {
-    @child expressions: Expressions | null;
+    @child expressions: Expressions;
     @child callInfo: CallInfo | null;
 
-    constructor(expressions: Expressions | null) {
+    constructor(expressions: Expressions) {
         super();
         this.expressions = expressions; // analyzer 패스를 거친 뒤로는 무의미
         this.callInfo = null; // analyzer 패스를 거친 뒤부터 접근 가능
@@ -192,10 +192,10 @@ export class Call extends Expression {
 
 export class ModuleCall extends Expression {
     @child target: any;
-    @child expressions: Expressions | null;
+    @child expressions: Expressions;
     @child callInfo: CallInfo | null;
 
-    constructor(target: any, expressions: Expressions | null) {
+    constructor(target: any, expressions: Expressions) {
         super();
         this.target = target;
         this.expressions = expressions; // analyzer 패스를 거친 뒤로는 무의미
@@ -213,10 +213,10 @@ export class ModuleCall extends Expression {
 }
 
 export class CallBind extends Expression {
-    @child expressions: Expressions | null;
+    @child expressions: Expressions;
     @child callInfo: CallInfo | null;
 
-    constructor(expressions: Expressions | null) {
+    constructor(expressions: Expressions) {
         super();
         this.expressions = expressions;
         this.callInfo = null;
@@ -228,10 +228,10 @@ export class CallBind extends Expression {
 
 export class ModuleCallBind extends Expression {
     @child target: any;
-    @child expressions: Expressions | null;
+    @child expressions: Expressions;
     @child callInfo: CallInfo | null;
 
-    constructor(target: any, expressions: Expressions | null) {
+    constructor(target: any, expressions: Expressions) {
         super();
         this.target = target;
         this.expressions = expressions;
@@ -621,12 +621,13 @@ export class DescriptionName extends AstNode {
 // defs
 @def
 export abstract class Def extends Statement {
-    @child description: Description | null = null;
+    @child description: Description;
     scope: any;
     returnType: any;
     used: boolean;
-    constructor() {
+    constructor(description: Description) {
         super();
+        this.description = description;
         this.scope = null;
         this.returnType = null;
         this.used = false; // 어딘가에서 호출된 적이 있는 정의인지 여부.
@@ -641,8 +642,7 @@ export abstract class Def extends Statement {
 export class Yaksok extends Def {
     @child block: any;
     constructor(description: Description, block: any) {
-        super();
-        this.description = description;
+        super(description);
         this.block = block;
     }
     get hasSideEffect() {
@@ -658,8 +658,7 @@ export class Translate extends Def {
     target: any;
     code: any;
     constructor(description: Description, target: any, code: any) {
-        super();
-        this.description = description;
+        super(description);
         this.target = target; // string
         this.code = code; // string
     }

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -258,7 +258,6 @@ export class Primitive extends Expression {
     }
 }
 export class Name extends Primitive {
-    value: any;
     call: boolean;
     constructor(value: any) {
         super(value);
@@ -640,7 +639,6 @@ export abstract class Def extends Statement {
 }
 
 export class Yaksok extends Def {
-    @child description: Description;
     @child block: any;
     constructor(description: Description, block: any) {
         super();
@@ -652,12 +650,11 @@ export class Yaksok extends Def {
         return super.hasSideEffect;
     }
     get repr() {
-        return `약속 ${ this.description.repr }`;
+        return `약속 ${ this.description?.repr }`;
     }
 }
 
 export class Translate extends Def {
-    @child description: Description;
     target: any;
     code: any;
     constructor(description: Description, target: any, code: any) {
@@ -667,7 +664,7 @@ export class Translate extends Def {
         this.code = code; // string
     }
     get repr() {
-        return `번역(${ this.target }) ${ this.description.repr }`;
+        return `번역(${ this.target }) ${ this.description?.repr }`;
     }
 }
 

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -5,10 +5,10 @@ const descriptionParser = new Parser(['START_DESCRIPTION']);
 
 export class Builtin extends ast.AstNode {}
 
-@ast.ast('description')
 @ast.def
 export class Yaksok extends Builtin {
-    constructor(description) {
+    @ast.child description: ast.Description;
+    constructor(description: string) {
         super();
         this.description = descriptionParser.parse(description);
     }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -9,10 +9,10 @@ const yy = {
     ast,
     stmts: (stmt: ast.Statement) => {
          const stmts = new ast.Statements();
-         (stmts as any as ast.Statement[] /* FIXME */).push(stmt);
+         stmts.push(stmt);
          return stmts;
     },
-    parseCall: (expressions: any /* FIXME: ast.Expressoins */) => {
+    parseCall: (expressions: ast.Expressions) => {
         if (expressions.length > 1) return new ast.Call(expressions);
         let expression = expressions.childNodes[0];
         if (expression instanceof ast.Name) {
@@ -23,7 +23,7 @@ const yy = {
     postprocessDescription: (description: ast.Description) => {
         const filteredDescription = new ast.Description();
         let whitespace = false;
-        for (let item of (description as any /* FIXME */)) {
+        for (let item of description) {
             if (item === null) {
                 whitespace = true;
             } else {
@@ -31,7 +31,7 @@ const yy = {
                     item.needWhiteSpace = whitespace;
                     item.sort();
                 }
-                (filteredDescription as any /* FIXME */).push(item);
+                filteredDescription.push(item);
                 whitespace = false;
             }
         }

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -18,7 +18,7 @@ async function main() {
         };
 
         let Mocha = eval('require("mocha")');
-        let reqTest = require.context('.', true, /^\.\/.*test-[^/]+\.js$/i);
+        let reqTest = require.context('.', true, /^\.\/.*test-[^/]+\.(js|ts)$/i);
         Mocha.prototype.loadFiles = function (fn) {
             for (let file of this.files) {
                 this.suite.emit('pre-require', global, file, this);

--- a/src/test/test-ast.ts
+++ b/src/test/test-ast.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import { AstNode, child, allChildFields } from '~/ast/base';
+import { Name } from '~/ast';
 
 describe('AstNode', () => {
     class Foo extends AstNode {
@@ -44,5 +45,12 @@ describe('AstNode', () => {
             (b as any).foo = undefined;
             assert.strictEqual(b.foo, null);
         });
+    });
+});
+
+describe('Name', () => {
+    specify('constructor', () => {
+        const foo = new Name('아무개');
+        assert.strictEqual(foo.value, '아무개');
     });
 });

--- a/src/test/test-ast.ts
+++ b/src/test/test-ast.ts
@@ -1,0 +1,31 @@
+import assert from 'assert';
+
+import { AstNode, child, allChildFields } from '~/ast/base';
+
+describe('AstNode', () => {
+    class Foo extends AstNode {
+        @child foo: Foo | null;
+
+        constructor(foo: Foo) {
+            super();
+            this.foo = foo;
+        }
+    }
+
+    class Bar extends Foo {
+        @child bar: Foo | null;
+
+        constructor(foo: Foo, bar: Foo) {
+            super(foo);
+            this.bar = bar;
+        }
+    }
+
+    specify('all childFields of Foo', () => {
+        assert.deepStrictEqual(['foo'], Array.from(allChildFields(Foo)));
+    });
+
+    specify('all childFields of Bar', () => {
+        assert.deepStrictEqual(['bar', 'foo'], Array.from(allChildFields(Bar)));
+    });
+});

--- a/src/test/test-ast.ts
+++ b/src/test/test-ast.ts
@@ -23,11 +23,11 @@ describe('AstNode', () => {
     }
 
     specify('all childFields of Foo', () => {
-        assert.deepStrictEqual(['foo'], Array.from(allChildFields(Foo)));
+        assert.deepStrictEqual(['foo'], Array.from(allChildFields(Foo.prototype)));
     });
 
     specify('all childFields of Bar', () => {
-        assert.deepStrictEqual(['bar', 'foo'], Array.from(allChildFields(Bar)));
+        assert.deepStrictEqual(['bar', 'foo'], Array.from(allChildFields(Bar.prototype)));
     });
 
     describe('@child', () => {

--- a/src/test/test-ast.ts
+++ b/src/test/test-ast.ts
@@ -6,7 +6,7 @@ describe('AstNode', () => {
     class Foo extends AstNode {
         @child foo: Foo | null;
 
-        constructor(foo: Foo) {
+        constructor(foo: Foo | null) {
             super();
             this.foo = foo;
         }
@@ -15,7 +15,7 @@ describe('AstNode', () => {
     class Bar extends Foo {
         @child bar: Foo | null;
 
-        constructor(foo: Foo, bar: Foo) {
+        constructor(foo: Foo | null, bar: Foo | null) {
             super(foo);
             this.bar = bar;
         }
@@ -27,5 +27,22 @@ describe('AstNode', () => {
 
     specify('all childFields of Bar', () => {
         assert.deepStrictEqual(['bar', 'foo'], Array.from(allChildFields(Bar)));
+    });
+
+    describe('@child', () => {
+        it('should replace given field to a property', () => {
+            const descriptor = Object.getOwnPropertyDescriptor(Foo.prototype, 'foo');
+            assert.notEqual(descriptor, null);
+            assert.strictEqual(descriptor?.configurable, true);
+            assert.strictEqual(descriptor?.enumerable, false);
+        });
+
+        it('should enforce undefined to be null', () => {
+            const a = new Foo(null);
+            const b = new Foo(a);
+            assert.strictEqual(b.foo, a);
+            (b as any).foo = undefined;
+            assert.strictEqual(b.foo, null);
+        });
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "types": [
-      "node"
+      "node",
+      "mocha"
     ],
     "baseUrl": "./",
     "paths": {


### PR DESCRIPTION
기존의 `@ast` 클래스 데코레이터를 쓰기에는 지정한 필드들의 타입까지 지정해야 하고, 결과로 나오는 클래스에도 추가된 필드들을 반영해야 한다는 문제가 있었습니다. 이 문제를 우회하기 위해 `@child` 프로퍼티 데코레이터로 대체했습니다. `@astList` 데코레이터는 추가하는 필드가 하나밖에 없는 대신 추가하는 메서드가 많고, 현재 구조에서 하나의 상위 클래스를 공유하게 만들기도 어려워 보여서 [믹스인][1]을 사용하는 것으로 대체했습니다.

무슨 타입이 들어가야 할 지 애매한 필드는 일단 타입을 `any`로 넣어 두었습니다.

[1]: https://www.typescriptlang.org/docs/handbook/mixins.html