### PR TITLE
TypeScript 마이그레이션: analyzer

### DIFF
--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -5,12 +5,14 @@ const descriptionParser = new Parser(['START_DESCRIPTION']);
 
 export class Builtin extends ast.AstNode {}
 
-@ast.def
 export class Yaksok extends Builtin {
     @ast.child description: ast.Description;
     constructor(description: string) {
         super();
         this.description = descriptionParser.parse(description);
+    }
+    match(call: ast.CallLike) { // return call info or null
+        return this.description.match(call.expressions);
     }
 }
 


### PR DESCRIPTION
`ast.Call`과 `ast.CallBind`, `ast.ModuleCall`과 `ast.ModuleCallBind`가 각각 analyzer에서 유사하게 취급되고 있었는데, `Call`과 `CallBind` 둘 사이에 어느 쪽으로든 상속 관계를 만들기가 애매해서 별도로 `CallLike` 및 `ModuleCallLike` 인터페이스를 두는 식으로 때워 두었습니다.

또한 기존의 `@ast.def` 데코레이터로는 클래스에 새로운 메서드를 추가했다는 걸 타입에 반영할 방법이 없었기에, 그냥 `ast.Def`와 `builtin.Yaksok` 각각에 직접 해당 메서드를 추가하는 식으로 우회했습니다.