### PR TITLE
TypeScript 마이그레이션: translator

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -54,6 +54,9 @@ export class Analyzer extends NodeVisitor {
         let moduleHash = this.currentAstRoot.modules[node.target.value];
         let moduleAstRoot = await this.compiler.getAstRoot(moduleHash);
         let { moduleScope } = moduleAstRoot;
+        if (moduleScope == null) {
+            throw new Error('moduleScope가 아직 resolve되지 않았습니다');
+        }
         let callInfo = moduleScope.getCallInfo(node);
         node.callInfo = callInfo;
         for (let arg of callInfo.args) {

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -541,7 +541,7 @@ export class CallInfo extends AstNode {
 export interface CallInfo extends AstListMixin {}
 
 // description
-export class Description extends AstNodeList<Expression> {
+export class Description extends AstNodeList<DescriptionItem> {
     match(expressions: Expressions): CallInfo | null {
         if (expressions.length > this.length) return null;
         let callInfo = new CallInfo(this.parent);
@@ -582,17 +582,23 @@ export class Description extends AstNodeList<Expression> {
         }
         return callInfo;
     }
-    get parameters() {
-        return this.childNodes.filter(item => item instanceof DescriptionParameter);
+    get parameters(): DescriptionParameter[] {
+        function predicate(item: DescriptionItem): item is DescriptionParameter {
+            return item instanceof DescriptionParameter;
+        }
+        return this.childNodes.filter(predicate);
     }
     get repr() { return this.childNodes.map(expression => expression.repr).join(''); }
 }
-export class DescriptionParameter extends AstNode {
+export abstract class DescriptionItem extends AstNode {
+    abstract get repr(): string;
+}
+export class DescriptionParameter extends DescriptionItem {
     value: any;
     constructor(value: any) { super(); this.value = value; }
     get repr() { return `(${ this.value })`; }
 }
-export class DescriptionName extends AstNode {
+export class DescriptionName extends DescriptionItem {
     names: string[];
     constructor() {
         super();

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -1,6 +1,7 @@
 // NOTE: 이 파일에서 String, Number, Boolean은 javascript builtin object가 아닙니다.
 
 import { AstNode, AstListMixin, astList, child } from './base';
+import { ModuleScope } from '~/analyzer';
 
 export { AstNode, child };
 
@@ -18,8 +19,8 @@ export interface AstNodeList<T> extends AstListMixin<T> {}
 
 export class YaksokRoot extends AstNode {
     hash: any;
-    modules: any;
-    moduleScope: any;
+    modules: { [name: string]: string };
+    moduleScope: ModuleScope | null;
     @child statements: Statements;
 
     constructor(statements: Statements) {

--- a/src/compiler/JsTargetCompiler.ts
+++ b/src/compiler/JsTargetCompiler.ts
@@ -1,4 +1,4 @@
-import { YaksokRoot } from '~/ast';
+import { Call, YaksokRoot } from '~/ast';
 import Compiler from '~/compiler/Compiler';
 import { Parser } from '~/parser';
 import { JsTranslator } from '~/translator';
@@ -6,7 +6,7 @@ import { JsTranslator } from '~/translator';
 const callParser = new Parser(['START_CALL']);
 
 export default class JsTargetCompiler extends Compiler {
-    exports: { [key: string]: any } | null;
+    exports: { [key: string]: Call } | null;
 
     constructor(...args: ConstructorParameters<typeof Compiler>) {
         super(...args);

--- a/src/translator/TextTranslator.ts
+++ b/src/translator/TextTranslator.ts
@@ -1,15 +1,19 @@
+import { YaksokRoot } from '~/ast';
 import Translator from '~/translator/Translator';
 
 export default class TextTranslator extends Translator {
+    result: (string | { toString(): string })[] = [];
+    indent = 0;
+
     async init() {
         await super.init();
         this.result = [];
         this.indent = 0;
     }
-    lazyWrite(func) { this.result.push({toString: func}); }
-    write(code) { this.result.push(code); }
+    lazyWrite(func: () => string) { this.result.push({ toString: func }); }
+    write(code: string) { this.result.push(code); }
     writeIndent() { this.result.push(Array(this.indent + 1).join('    ')); }
-    async translate(astRoot) {
+    async translate(astRoot: YaksokRoot) {
         await super.translate(astRoot);
         return this.result.join('');
     }

--- a/src/translator/index.js
+++ b/src/translator/index.js
@@ -1,8 +1,0 @@
-import Translator from './Translator';
-import TextTranslator from './TextTranslator';
-import JsTranslator from './JsTranslator';
-export {
-    JsTranslator,
-    TextTranslator,
-    Translator,
-};

--- a/src/translator/index.ts
+++ b/src/translator/index.ts
@@ -1,0 +1,3 @@
+export { default as Translator } from './Translator';
+export { default as TextTranslator } from './TextTranslator';
+export { default as JsTranslator } from './JsTranslator';

--- a/types/loader.d.ts
+++ b/types/loader.d.ts
@@ -1,0 +1,4 @@
+declare module 'raw-loader!*' {
+    const content: string;
+    export default content;
+}


### PR DESCRIPTION
작업 과정에서 기존에 잘못 정의되었던 `Description.parameters`와 `JsTargetCompiler.exports`의 타입을 고치고, `any`로 남겨두었던 `YaksokRoot.modules` 및 `YaksokRoot.moduleScope`의 타입을 구체적으로 정했습니다.