### PR TITLE
BinaryOperator의 서브클래스들을 하나로 통폐합

### DIFF
--- a/src/ast/NodeVisitor.ts
+++ b/src/ast/NodeVisitor.ts
@@ -119,38 +119,9 @@ export default class NodeVisitor {
     async visitUnaryPlus(node: ast.UnaryPlus) { await visitUnaryOperator.call(this, node); }
     async visitUnaryMinus(node: ast.UnaryMinus) { await visitUnaryOperator.call(this, node); }
     async visitBinaryOperator(node: ast.BinaryOperator) {
-        if (node instanceof ast.Access) return await this.visitAccess(node);
-        if (node instanceof ast.DotAccess) return await this.visitDotAccess(node);
-        if (node instanceof ast.Or) return await this.visitOr(node);
-        if (node instanceof ast.And) return await this.visitAnd(node);
-        if (node instanceof ast.Equal) return await this.visitEqual(node);
-        if (node instanceof ast.NotEqual) return await this.visitNotEqual(node);
-        if (node instanceof ast.GreaterThan) return await this.visitGreaterThan(node);
-        if (node instanceof ast.LessThan) return await this.visitLessThan(node);
-        if (node instanceof ast.GreaterThanEqual) return await this.visitGreaterThanEqual(node);
-        if (node instanceof ast.LessThanEqual) return await this.visitLessThanEqual(node);
-        if (node instanceof ast.Plus) return await this.visitPlus(node);
-        if (node instanceof ast.Minus) return await this.visitMinus(node);
-        if (node instanceof ast.Multiply) return await this.visitMultiply(node);
-        if (node instanceof ast.Divide) return await this.visitDivide(node);
-        if (node instanceof ast.Modular) return await this.visitModular(node);
-        throw new Error('unknown node type');
+        await this.visit(node.lhs);
+        await this.visit(node.rhs);
     }
-    async visitAccess(node: ast.Access) { await visitOperator.call(this, node); }
-    async visitDotAccess(node: ast.DotAccess) { await visitOperator.call(this, node); }
-    async visitOr(node: ast.Or) { await visitOperator.call(this, node); }
-    async visitAnd(node: ast.And) { await visitOperator.call(this, node); }
-    async visitEqual(node: ast.Equal) { await visitOperator.call(this, node); }
-    async visitNotEqual(node: ast.NotEqual) { await visitOperator.call(this, node); }
-    async visitGreaterThan(node: ast.GreaterThan) { await visitOperator.call(this, node); }
-    async visitLessThan(node: ast.LessThan) { await visitOperator.call(this, node); }
-    async visitGreaterThanEqual(node: ast.GreaterThanEqual) { await visitOperator.call(this, node); }
-    async visitLessThanEqual(node: ast.LessThanEqual) { await visitOperator.call(this, node); }
-    async visitPlus(node: ast.Plus) { await visitOperator.call(this, node); }
-    async visitMinus(node: ast.Minus) { await visitOperator.call(this, node); }
-    async visitMultiply(node: ast.Multiply) { await visitOperator.call(this, node); }
-    async visitDivide(node: ast.Divide) { await visitOperator.call(this, node); }
-    async visitModular(node: ast.Modular) { await visitOperator.call(this, node); }
     async visitDescription(node: ast.Description) {}
     async visitDescriptionParameter(node: ast.DescriptionParameter) {}
     async visitDescriptionName(node: ast.DescriptionName) {}
@@ -166,10 +137,5 @@ export default class NodeVisitor {
 }
 
 async function visitUnaryOperator(this: NodeVisitor, node: ast.UnaryOperator) {
-    await this.visit(node.rhs);
-}
-
-async function visitOperator(this: NodeVisitor, node: ast.BinaryOperator) {
-    await this.visit(node.lhs);
     await this.visit(node.rhs);
 }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -7,6 +7,7 @@ const yy = {
     parseInteger: (text: string) => (text as any) | 0,
     parseFloat: (text: string) => +text,
     ast,
+    op: ast.OperatorKind,
     stmts: (stmt: ast.Statement) => {
          const stmts = new ast.Statements();
          stmts.push(stmt);

--- a/src/parser/parser.jison
+++ b/src/parser/parser.jison
@@ -173,35 +173,35 @@ expression
     ;
 
 or_expression
-    : or_expression OR and_expression   { $$ = new yy.ast.Or($1, $3) }
+    : or_expression OR and_expression   { $$ = new yy.ast.BinaryOperator(yy.op.Or, $1, $3) }
     | and_expression                    { $$ = $1 }
     ;
 
 and_expression
-    : and_expression AND logical_expression     { $$ = new yy.ast.And($1, $3) }
+    : and_expression AND logical_expression     { $$ = new yy.ast.BinaryOperator(yy.op.And, $1, $3) }
     | logical_expression                        { $$ = $1 }
     ;
 
 logical_expression
-    : additive_expression EQ additive_expression    { $$ = new yy.ast.Equal($1, $3) }
-    | additive_expression NE additive_expression    { $$ = new yy.ast.NotEqual($1, $3) }
-    | additive_expression GT additive_expression    { $$ = new yy.ast.GreaterThan($1, $3) }
-    | additive_expression LT additive_expression    { $$ = new yy.ast.LessThan($1, $3) }
-    | additive_expression GTEQ additive_expression  { $$ = new yy.ast.GreaterThanEqual($1, $3) }
-    | additive_expression LTEQ additive_expression  { $$ = new yy.ast.LessThanEqual($1, $3) }
+    : additive_expression EQ additive_expression    { $$ = new yy.ast.BinaryOperator(yy.op.Equal, $1, $3) }
+    | additive_expression NE additive_expression    { $$ = new yy.ast.BinaryOperator(yy.op.NotEqual, $1, $3) }
+    | additive_expression GT additive_expression    { $$ = new yy.ast.BinaryOperator(yy.op.GreaterThan, $1, $3) }
+    | additive_expression LT additive_expression    { $$ = new yy.ast.BinaryOperator(yy.op.LessThan, $1, $3) }
+    | additive_expression GTEQ additive_expression  { $$ = new yy.ast.BinaryOperator(yy.op.GreaterThanEqual, $1, $3) }
+    | additive_expression LTEQ additive_expression  { $$ = new yy.ast.BinaryOperator(yy.op.LessThanEqual, $1, $3) }
     | additive_expression                           { $$ = $1 }
     ;
 
 additive_expression
-    : additive_expression PLUS multiplicative_expression    { $$ = new yy.ast.Plus($1, $3) }
-    | additive_expression MINUS multiplicative_expression   { $$ = new yy.ast.Minus($1, $3) }
+    : additive_expression PLUS multiplicative_expression    { $$ = new yy.ast.BinaryOperator(yy.op.Plus, $1, $3) }
+    | additive_expression MINUS multiplicative_expression   { $$ = new yy.ast.BinaryOperator(yy.op.Minus, $1, $3) }
     | multiplicative_expression                             { $$ = $1 }
     ;
 
 multiplicative_expression
-    : multiplicative_expression MULT prefix_expression      { $$ = new yy.ast.Multiply($1, $3) }
-    | multiplicative_expression DIV prefix_expression       { $$ = new yy.ast.Divide($1, $3) }
-    | multiplicative_expression MOD prefix_expression       { $$ = new yy.ast.Modular($1, $3) }
+    : multiplicative_expression MULT prefix_expression      { $$ = new yy.ast.BinaryOperator(yy.op.Multiply, $1, $3) }
+    | multiplicative_expression DIV prefix_expression       { $$ = new yy.ast.BinaryOperator(yy.op.Divide, $1, $3) }
+    | multiplicative_expression MOD prefix_expression       { $$ = new yy.ast.BinaryOperator(yy.op.Modular, $1, $3) }
     | prefix_expression                                     { $$ = $1 }
     ;
 
@@ -230,8 +230,8 @@ lvalue
     ;
 
 access_expression
-    : primary_expression LSQUARE expression RSQUARE     { $$ = new yy.ast.Access($1, $3) }
-    | primary_expression DOT name                       { $$ = new yy.ast.DotAccess($1, $3) }
+    : primary_expression LSQUARE expression RSQUARE     { $$ = new yy.ast.BinaryOperator(yy.op.Access, $1, $3) }
+    | primary_expression DOT name                       { $$ = new yy.ast.BinaryOperator(yy.op.DotAccess, $1, $3) }
     ;
 
 name

--- a/src/translator/JsTranslator.ts
+++ b/src/translator/JsTranslator.ts
@@ -345,9 +345,12 @@ export default class JsTranslator extends TextTranslator {
             await this.visit(node.rhs);
             break;
         default:
+            if (!(node.kind in reprOp)) {
+                throw new Error('invalid operator: ' + ast.OperatorKind[node.kind]);
+            }
             this.write('(');
             await this.visit(node.lhs);
-            this.write(` ${ reprOp(node.kind) } `);
+            this.write(` ${ reprOp[node.kind] } `);
             await this.visit(node.rhs);
             this.write(')');
         }
@@ -387,38 +390,21 @@ async function uop(this: JsTranslator, node: ast.UnaryOperator, op: string) {
     this.write(')');
 }
 
-function reprOp(op: ast.OperatorKind): string {
-    switch (op) {
-    case ast.OperatorKind.Or:
-        return '||';
-    case ast.OperatorKind.And:
-        return '&&';
-    case ast.OperatorKind.Equal:
-        return '===';
-    case ast.OperatorKind.NotEqual:
-        return '!==';
-    case ast.OperatorKind.GreaterThan:
-        return '>';
-    case ast.OperatorKind.LessThan:
-        return '<';
-    case ast.OperatorKind.GreaterThanEqual:
-        return '>=';
-    case ast.OperatorKind.LessThanEqual:
-        return '<=';
-    case ast.OperatorKind.Plus:
-        return '+';
-    case ast.OperatorKind.Minus:
-        return '-';
-    case ast.OperatorKind.Multiply:
-        return '*';
-    case ast.OperatorKind.Divide:
-        return '/';
-    case ast.OperatorKind.Modular:
-        return '%';
-    default:
-        throw new Error('invalid operator: ' + ast.OperatorKind[op]);
-    }
-}
+const reprOp = {
+    [ast.OperatorKind.Or]: '||',
+    [ast.OperatorKind.And]: '&&',
+    [ast.OperatorKind.Equal]: '===',
+    [ast.OperatorKind.NotEqual]: '!==',
+    [ast.OperatorKind.GreaterThan]: '>',
+    [ast.OperatorKind.LessThan]: '<',
+    [ast.OperatorKind.GreaterThanEqual]: '>=',
+    [ast.OperatorKind.LessThanEqual]: '<=',
+    [ast.OperatorKind.Plus]: '+',
+    [ast.OperatorKind.Minus]: '-',
+    [ast.OperatorKind.Multiply]: '*',
+    [ast.OperatorKind.Divide]: '/',
+    [ast.OperatorKind.Modular]: '%',
+};
 
 function yaksokNameToJsIdentifier(name: ast.DescriptionName) {
     let nameString = name.names[0];


### PR DESCRIPTION
AstNode 클래스 계층을 단순하게 만들기 위한 작업의 일환입니다.

기존 구조에서는 이항 연산자마다 각각 클래스가 하나씩 만들어져 있었는데, 연산자 종류나 연산자에 따른 결과 타입의 차이 외에는 거의 차이가 없는 클래스가 너무 많아 클래스 계층도와 NodeVisitor를 복잡하게 만들고 있었다고 판단했습니다. 따라서 이를 BinaryOperator 클래스로 하나로 합치고, 연산자 종류에 따른 차이를 다루기 위해 별도로 OperatorKind 타입을 분리하는 것을 제안합니다.

다만 Access와 DotAccess는 다른 이항 연산자와 동일하게 취급하기에는 이질적인 부분들이 있어, 이 둘은 BinaryOperator보다 상위의 클래스로 별도로 분리하는 것도 고려해볼 수 있겠습니다.